### PR TITLE
RHCLOUD-38741 - Add a sample server side config to toggle read-after-write requests

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -160,6 +160,9 @@ func NewCommand(
 
 			// setup the driver listener
 			listener := pubsub.NewDriver(pgxPool)
+			if err := listener.Connect(ctx); err != nil {
+				return fmt.Errorf("error setting up listener: %v", err)
+			}
 			err = listener.Listen(ctx, "consumer-notifications")
 			if err != nil {
 				return fmt.Errorf("error setting up listener: %v", err)
@@ -229,14 +232,14 @@ func NewCommand(
 			//v1beta2
 			// wire together resource handling
 			resource_repo := resourcerepo.New(db)
-			resource_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager)
+			resource_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
 			resource_service := resourcesvc.New(resource_controller)
 			pbv1beta2.RegisterKesselResourceServiceServer(server.GrpcServer, resource_service)
 			pbv1beta2.RegisterKesselResourceServiceHTTPServer(server.HttpServer, resource_service)
 
 			// wire together authz handling
 			authz_repov2 := resourcerepo.New(db)
-			authz_controllerv2 := resourcesctl.New(authz_repov2, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager)
+			authz_controllerv2 := resourcesctl.New(authz_repov2, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
 			authz_servicev2 := authzsvc.NewV1beta2(authz_controllerv2)
 			authzv1beta2.RegisterKesselCheckServiceServer(server.GrpcServer, authz_servicev2)
 			authzv1beta2.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_servicev2)
@@ -244,35 +247,35 @@ func NewCommand(
 			//v1beta1
 			// wire together notificationsintegrations handling
 			notifs_repo := resourcerepo.New(db)
-			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager)
+			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
 			notifs_service := notifssvc.New(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together authz handling
 			authz_repo := resourcerepo.New(db)
-			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager)
+			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
 			authz_service := authzsvc.New(authz_controller)
 			authzv1beta1.RegisterKesselCheckServiceServer(server.GrpcServer, authz_service)
 			authzv1beta1.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_service)
 
 			// wire together hosts handling
 			hosts_repo := resourcerepo.New(db)
-			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence, listenManager)
+			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
 			hosts_service := hostssvc.New(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
 			k8sclusters_repo := resourcerepo.New(db)
-			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence, listenManager)
+			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
 			k8sclusters_service := k8sclusterssvc.New(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
 			k8spolicies_repo := resourcerepo.New(db)
-			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence, listenManager)
+			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
 			k8spolicies_service := k8spoliciessvc.New(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)
 			pb.RegisterKesselK8SPolicyServiceHTTPServer(server.HttpServer, k8spolicies_service)

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -150,27 +150,6 @@ func NewCommand(
 			if err != nil {
 				return err
 			}
-			// construct pubsub
-			pubSubLogger := log.NewHelper(log.With(logger, "subsystem", "pubsub"))
-			pgxPool, err := storage.NewPgx(storageConfig, pubSubLogger)
-			if err != nil {
-				// TODO should not completely fail for sqllite
-				return err
-			}
-
-			// setup the driver listener
-			listener := pubsub.NewDriver(pgxPool)
-			if err := listener.Connect(ctx); err != nil {
-				return fmt.Errorf("error setting up listener: %v", err)
-			}
-			err = listener.Listen(ctx, "consumer-notifications")
-			if err != nil {
-				return fmt.Errorf("error setting up listener: %v", err)
-			}
-
-			// setup the notifier
-			listenManager := pubsub.NewListenManager(pubSubLogger, listener)
-			go listenManager.Run(ctx)
 
 			// START: construct pubsub (postgres only)
 			var listenManager *pubsub.ListenManager
@@ -232,14 +211,14 @@ func NewCommand(
 			//v1beta2
 			// wire together resource handling
 			resource_repo := resourcerepo.New(db)
-			resource_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
+			resource_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, consumerConfig.ReadAfterWriteEnabled, consumerConfig.ReadAfterWriteAllowlist)
 			resource_service := resourcesvc.New(resource_controller)
 			pbv1beta2.RegisterKesselResourceServiceServer(server.GrpcServer, resource_service)
 			pbv1beta2.RegisterKesselResourceServiceHTTPServer(server.HttpServer, resource_service)
 
 			// wire together authz handling
 			authz_repov2 := resourcerepo.New(db)
-			authz_controllerv2 := resourcesctl.New(authz_repov2, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
+			authz_controllerv2 := resourcesctl.New(authz_repov2, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager, consumerConfig.ReadAfterWriteEnabled, consumerConfig.ReadAfterWriteAllowlist)
 			authz_servicev2 := authzsvc.NewV1beta2(authz_controllerv2)
 			authzv1beta2.RegisterKesselCheckServiceServer(server.GrpcServer, authz_servicev2)
 			authzv1beta2.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_servicev2)
@@ -247,35 +226,35 @@ func NewCommand(
 			//v1beta1
 			// wire together notificationsintegrations handling
 			notifs_repo := resourcerepo.New(db)
-			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
+			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager, consumerConfig.ReadAfterWriteEnabled, consumerConfig.ReadAfterWriteAllowlist)
 			notifs_service := notifssvc.New(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together authz handling
 			authz_repo := resourcerepo.New(db)
-			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
+			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager, consumerConfig.ReadAfterWriteEnabled, consumerConfig.ReadAfterWriteAllowlist)
 			authz_service := authzsvc.New(authz_controller)
 			authzv1beta1.RegisterKesselCheckServiceServer(server.GrpcServer, authz_service)
 			authzv1beta1.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_service)
 
 			// wire together hosts handling
 			hosts_repo := resourcerepo.New(db)
-			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
+			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence, listenManager, consumerConfig.ReadAfterWriteEnabled, consumerConfig.ReadAfterWriteAllowlist)
 			hosts_service := hostssvc.New(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
 			k8sclusters_repo := resourcerepo.New(db)
-			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
+			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence, listenManager, consumerConfig.ReadAfterWriteEnabled, consumerConfig.ReadAfterWriteAllowlist)
 			k8sclusters_service := k8sclusterssvc.New(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
 			k8spolicies_repo := resourcerepo.New(db)
-			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence, listenManager, inventoryConsumer)
+			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence, listenManager, consumerConfig.ReadAfterWriteEnabled, consumerConfig.ReadAfterWriteAllowlist)
 			k8spolicies_service := k8spoliciessvc.New(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)
 			pb.RegisterKesselK8SPolicyServiceHTTPServer(server.HttpServer, k8spolicies_service)

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -17,6 +17,7 @@ import (
 	inventoryResourcesRepo "github.com/project-kessel/inventory-api/internal/data/inventoryresources"
 	relationshipsrepo "github.com/project-kessel/inventory-api/internal/data/relationships"
 	resourcerepo "github.com/project-kessel/inventory-api/internal/data/resources"
+	"github.com/project-kessel/inventory-api/internal/pubsub"
 	authzsvc "github.com/project-kessel/inventory-api/internal/service/authz"
 	relationshipssvc "github.com/project-kessel/inventory-api/internal/service/relationships/k8spolicy"
 	hostssvc "github.com/project-kessel/inventory-api/internal/service/resources/hosts"
@@ -150,6 +151,35 @@ func NewCommand(
 				return err
 			}
 
+			// START: construct pubsub (postgres only)
+			var listenManager *pubsub.ListenManager
+			var notifier *pubsub.Notifier
+			if storageConfig.Options.Database == "postgres" {
+				pubSubLogger := log.NewHelper(log.With(logger, "subsystem", "pubsub"))
+				pgxPool, err := storage.NewPgx(storageConfig, pubSubLogger)
+				if err != nil {
+					return err
+				}
+				listenerDriver := pubsub.NewDriver(pgxPool)
+				if err := listenerDriver.Connect(ctx); err != nil {
+					return fmt.Errorf("error setting up listenerDriver: %v", err)
+				}
+				err = listenerDriver.Listen(ctx)
+				if err != nil {
+					return fmt.Errorf("error setting up listener: %v", err)
+				}
+				listenManager = pubsub.NewListenManager(pubSubLogger, listenerDriver)
+				go listenManager.Run(ctx)
+
+				// Run notifier on a separate connection, as the listener requires it's own
+				notifierDriver := pubsub.NewDriver(pgxPool)
+				if err := notifierDriver.Connect(ctx); err != nil {
+					return fmt.Errorf("error setting up notifierDriver: %v", err)
+				}
+				notifier = pubsub.NewNotifier(notifierDriver)
+			}
+			// STOP: construct pubsub
+
 			// construct authn
 			authenticator, err := authn.New(authnConfig, log.NewHelper(log.With(logger, "subsystem", "authn")))
 			if err != nil {
@@ -181,14 +211,14 @@ func NewCommand(
 			//v1beta2
 			// wire together resource handling
 			resource_repo := resourcerepo.New(db)
-			resource_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence)
+			resource_controller := resourcesctl.New(resource_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager)
 			resource_service := resourcesvc.New(resource_controller)
 			pbv1beta2.RegisterKesselResourceServiceServer(server.GrpcServer, resource_service)
 			pbv1beta2.RegisterKesselResourceServiceHTTPServer(server.HttpServer, resource_service)
 
 			// wire together authz handling
 			authz_repov2 := resourcerepo.New(db)
-			authz_controllerv2 := resourcesctl.New(authz_repov2, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence)
+			authz_controllerv2 := resourcesctl.New(authz_repov2, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager)
 			authz_servicev2 := authzsvc.NewV1beta2(authz_controllerv2)
 			authzv1beta2.RegisterKesselCheckServiceServer(server.GrpcServer, authz_servicev2)
 			authzv1beta2.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_servicev2)
@@ -196,35 +226,35 @@ func NewCommand(
 			//v1beta1
 			// wire together notificationsintegrations handling
 			notifs_repo := resourcerepo.New(db)
-			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence)
+			notifs_controller := resourcesctl.New(notifs_repo, inventoryresources_repo, authorizer, eventingManager, "notifications", log.With(logger, "subsystem", "notificationsintegrations_controller"), storageConfig.Options.DisablePersistence, listenManager)
 			notifs_service := notifssvc.New(notifs_controller)
 			pb.RegisterKesselNotificationsIntegrationServiceServer(server.GrpcServer, notifs_service)
 			pb.RegisterKesselNotificationsIntegrationServiceHTTPServer(server.HttpServer, notifs_service)
 
 			// wire together authz handling
 			authz_repo := resourcerepo.New(db)
-			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence)
+			authz_controller := resourcesctl.New(authz_repo, inventoryresources_repo, authorizer, eventingManager, "authz", log.With(logger, "subsystem", "authz_controller"), storageConfig.Options.DisablePersistence, listenManager)
 			authz_service := authzsvc.New(authz_controller)
 			authzv1beta1.RegisterKesselCheckServiceServer(server.GrpcServer, authz_service)
 			authzv1beta1.RegisterKesselCheckServiceHTTPServer(server.HttpServer, authz_service)
 
 			// wire together hosts handling
 			hosts_repo := resourcerepo.New(db)
-			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence)
+			hosts_controller := resourcesctl.New(hosts_repo, inventoryresources_repo, authorizer, eventingManager, "hbi", log.With(logger, "subsystem", "hosts_controller"), storageConfig.Options.DisablePersistence, listenManager)
 			hosts_service := hostssvc.New(hosts_controller)
 			pb.RegisterKesselRhelHostServiceServer(server.GrpcServer, hosts_service)
 			pb.RegisterKesselRhelHostServiceHTTPServer(server.HttpServer, hosts_service)
 
 			// wire together k8sclusters handling
 			k8sclusters_repo := resourcerepo.New(db)
-			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence)
+			k8sclusters_controller := resourcesctl.New(k8sclusters_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8sclusters_controller"), storageConfig.Options.DisablePersistence, listenManager)
 			k8sclusters_service := k8sclusterssvc.New(k8sclusters_controller)
 			pb.RegisterKesselK8SClusterServiceServer(server.GrpcServer, k8sclusters_service)
 			pb.RegisterKesselK8SClusterServiceHTTPServer(server.HttpServer, k8sclusters_service)
 
 			// wire together k8spolicies handling
 			k8spolicies_repo := resourcerepo.New(db)
-			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence)
+			k8spolicies_controller := resourcesctl.New(k8spolicies_repo, inventoryresources_repo, authorizer, eventingManager, "acm", log.With(logger, "subsystem", "k8spolicies_controller"), storageConfig.Options.DisablePersistence, listenManager)
 			k8spolicies_service := k8spoliciessvc.New(k8spolicies_controller)
 			pb.RegisterKesselK8SPolicyServiceServer(server.GrpcServer, k8spolicies_service)
 			pb.RegisterKesselK8SPolicyServiceHTTPServer(server.HttpServer, k8spolicies_service)
@@ -256,7 +286,7 @@ func NewCommand(
 						// If the consumer cannot process a message, the consumer loop is restarted
 						// This is to ensure we re-read the message and prevent it being dropped and moving to next message.
 						// To re-read the current message, we have to recreate the consumer connection so that the earliest offset is used
-						inventoryConsumer, err = consumer.New(consumerConfig, db, authzConfig, authorizer, log.NewHelper(log.With(logger, "subsystem", "inventoryConsumer")))
+						inventoryConsumer, err = consumer.New(consumerConfig, db, authzConfig, authorizer, notifier, log.NewHelper(log.With(logger, "subsystem", "inventoryConsumer")))
 						if err != nil {
 							shutdown(err)
 						}

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -20,6 +20,8 @@ objects:
         consumer:
           bootstrap-servers: inventory-kafka-kafka-bootstrap:9092
           topic: outbox.event.kessel.tuples
+          read-after-write-enabled: true # false == off for all service providers
+          read-after-write-allowlist: [] # specify "*" to require all requests
         log:
           level: "debug"
 

--- a/deploy/kessel-inventory-ephem-w-debezium.yaml
+++ b/deploy/kessel-inventory-ephem-w-debezium.yaml
@@ -212,7 +212,7 @@ objects:
         table.include.list: public.outbox_events # Required for Debezium > v1.3.0
         transforms: outbox
         transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
-        transforms.outbox.table.fields.additional.placement: operation:header
+        transforms.outbox.table.fields.additional.placement: operation:header, txid:header
         plugin.name: pgoutput
         heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
         heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}

--- a/deploy/kind/inventory/strimzi.yaml
+++ b/deploy/kind/inventory/strimzi.yaml
@@ -80,5 +80,5 @@ spec:
     table.include.list: public.outbox_events # Required for Debezium > v1.3.0
     transforms: outbox
     transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
-    transforms.outbox.table.fields.additional.placement: operation:header
+    transforms.outbox.table.fields.additional.placement: operation:header, txid:header
     plugin.name: pgoutput

--- a/development/configs/debezium-connector.json
+++ b/development/configs/debezium-connector.json
@@ -11,7 +11,7 @@
     "table.include.list": "public.outbox_events",
     "transforms": "outbox",
     "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
-    "transforms.outbox.table.fields.additional.placement": "operation:header",
+    "transforms.outbox.table.fields.additional.placement": "operation:header,txid:header",
     "plugin.name": "pgoutput"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-kratos/kratos/v2 v2.8.4
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.7.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/project-kessel/inventory-client-go v0.0.0-20250220124954-dedacb3f2537
 	github.com/project-kessel/relations-api v0.0.0-20250325175123-adb587fbff16
@@ -59,7 +60,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.1 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/internal/biz/model/outboxevents.go
+++ b/internal/biz/model/outboxevents.go
@@ -24,6 +24,7 @@ type OutboxEvent struct {
 	AggregateType AggregateType      `gorm:"column:aggregatetype;type:varchar(255);not null"`
 	AggregateID   string             `gorm:"column:aggregateid;type:varchar(255);not null"`
 	Operation     EventOperationType `gorm:"type:varchar(255);not null"`
+	TxId          string             `gorm:"column:txid;type:varchar(255)"`
 	Payload       JsonObject
 }
 
@@ -241,7 +242,7 @@ func convertResourceToUnsetTupleEvent(resource Resource, namespace string) (Json
 	return payload, nil
 }
 
-func NewOutboxEventsFromResource(resource Resource, namespace string, operationType EventOperationType) (*OutboxEvent, *OutboxEvent, error) {
+func NewOutboxEventsFromResource(resource Resource, namespace string, operationType EventOperationType, txid string) (*OutboxEvent, *OutboxEvent, error) {
 	var tuplePayload JsonObject
 	var tupleEvent *OutboxEvent
 
@@ -255,6 +256,7 @@ func NewOutboxEventsFromResource(resource Resource, namespace string, operationT
 		Operation:     operationType,
 		AggregateType: ResourceAggregateType,
 		AggregateID:   resource.InventoryId.String(),
+		TxId:          "",
 		Payload:       payload,
 	}
 
@@ -274,6 +276,7 @@ func NewOutboxEventsFromResource(resource Resource, namespace string, operationT
 		Operation:     operationType,
 		AggregateType: TupleAggregateType,
 		AggregateID:   resource.InventoryId.String(),
+		TxId:          txid,
 		Payload:       tuplePayload,
 	}
 

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/project-kessel/inventory-api/internal/consumer"
@@ -69,6 +70,7 @@ func New(reporterResourceRepository ReporterResourceRepository, inventoryResourc
 		log:                         log.NewHelper(logger),
 		DisablePersistence:          disablePersistence,
 		ListenManager:               listenManager,
+		Consumer:                    consumer,
 	}
 }
 
@@ -268,6 +270,18 @@ func (uc *Usecase) ListResourcesInWorkspace(ctx context.Context, permission, nam
 	}()
 
 	return resource_chan, error_chan, nil
+}
+
+// Check if request comes from SP in allowlist
+func isSPInAllowlist(m *model.Resource, allowlist []string) bool {
+	fmt.Printf("SPs in allowlist: %+q\n", allowlist)
+	for _, sp := range allowlist {
+		if sp == m.ReporterId || sp == "*" { // either specific SP or everyone
+			return true
+		}
+	}
+
+	return false
 }
 
 // Deprecated. Remove after notifications and ACM migrates to v1beta2

--- a/internal/biz/resources/resources.go
+++ b/internal/biz/resources/resources.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/project-kessel/inventory-api/internal/consumer"
@@ -56,11 +55,13 @@ type Usecase struct {
 	Server                      server.Server
 	DisablePersistence          bool
 	ListenManager               *pubsub.ListenManager
+	ReadAfterWriteEnabled       bool
+	ReadAfterWriteAllowlist     []string
 }
 
 func New(reporterResourceRepository ReporterResourceRepository, inventoryResourceRepository InventoryResourceRepository,
 	authz authzapi.Authorizer, eventer eventingapi.Manager, namespace string, logger log.Logger, disablePersistence bool,
-	listenManager *pubsub.ListenManager) *Usecase {
+	listenManager *pubsub.ListenManager, readAfterWriteEnabled bool, readAfterWriteAllowlist []string) *Usecase {
 	return &Usecase{
 		reporterResourceRepository:  reporterResourceRepository,
 		inventoryResourceRepository: inventoryResourceRepository,
@@ -70,7 +71,8 @@ func New(reporterResourceRepository ReporterResourceRepository, inventoryResourc
 		log:                         log.NewHelper(logger),
 		DisablePersistence:          disablePersistence,
 		ListenManager:               listenManager,
-		Consumer:                    consumer,
+		ReadAfterWriteEnabled:       readAfterWriteEnabled,
+		ReadAfterWriteAllowlist:     readAfterWriteAllowlist,
 	}
 }
 
@@ -272,18 +274,6 @@ func (uc *Usecase) ListResourcesInWorkspace(ctx context.Context, permission, nam
 	return resource_chan, error_chan, nil
 }
 
-// Check if request comes from SP in allowlist
-func isSPInAllowlist(m *model.Resource, allowlist []string) bool {
-	fmt.Printf("SPs in allowlist: %+q\n", allowlist)
-	for _, sp := range allowlist {
-		if sp == m.ReporterId || sp == "*" { // either specific SP or everyone
-			return true
-		}
-	}
-
-	return false
-}
-
 // Deprecated. Remove after notifications and ACM migrates to v1beta2
 func (uc *Usecase) Create(ctx context.Context, m *model.Resource) (*model.Resource, error) {
 	ret := m // Default to returning the input model in case persistence is disabled
@@ -323,12 +313,19 @@ func (uc *Usecase) Create(ctx context.Context, m *model.Resource) (*model.Resour
 		}
 
 		if uc.ListenManager != nil {
-			timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
 
-			err = subscription.BlockForNotification(timeoutCtx)
-			if err != nil {
-				return nil, err
+			// read after write functionality is enabled globally.
+			// And executed if request came from service provider in allowlist
+			if uc.ReadAfterWriteEnabled && isSPInAllowlist(m, uc.ReadAfterWriteAllowlist) {
+
+				// 30 sec max timeout
+				timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				defer cancel()
+
+				err = subscription.BlockForNotification(timeoutCtx)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -424,4 +421,16 @@ func (uc *Usecase) Delete(ctx context.Context, id model.ReporterResourceId) erro
 	uc.log.WithContext(ctx).Infof("Deleted Resource: %v(%v)", m.ID, m.ResourceType)
 	return nil
 
+}
+
+// Check if request comes from SP in allowlist
+func isSPInAllowlist(m *model.Resource, allowlist []string) bool {
+	for _, sp := range allowlist {
+		// either specific SP or everyone
+		if sp == m.ReporterId || sp == "*" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,7 +75,10 @@ func LogConfigurationInfo(options *OptionsConfig) {
 		options.Consumer.Topic,
 		options.Consumer.RetryOptions.ConsumerMaxRetries,
 		options.Consumer.RetryOptions.OperationMaxRetries,
-		options.Consumer.RetryOptions.BackoffFactor)
+		options.Consumer.RetryOptions.BackoffFactor,
+		options.Consumer.ReadAfterWriteEnabled,
+		options.Consumer.ReadAfterWriteAllowlist,
+	)
 }
 
 // InjectClowdAppConfig updates service options based on values in the ClowdApp AppConfig

--- a/internal/consumer/config.go
+++ b/internal/consumer/config.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"fmt"
+
 	"github.com/project-kessel/inventory-api/internal/consumer/retry"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
@@ -18,9 +19,11 @@ type Config struct {
 
 type completedConfig struct {
 	*Options
-	Topic       string
-	KafkaConfig *kafka.ConfigMap
-	RetryConfig *retry.Config
+	Topic                   string
+	KafkaConfig             *kafka.ConfigMap
+	RetryConfig             *retry.Config
+	ReadAfterWriteEnabled   bool
+	ReadAfterWriteAllowlist []string
 }
 
 type CompletedConfig struct {
@@ -81,9 +84,11 @@ func (c *Config) Complete() (CompletedConfig, []error) {
 		return CompletedConfig{}, errs
 	}
 	return CompletedConfig{&completedConfig{
-		KafkaConfig: config,
-		Topic:       c.Topic,
-		Options:     c.Options,
-		RetryConfig: c.RetryConfig,
+		KafkaConfig:             config,
+		Topic:                   c.Topic,
+		Options:                 c.Options,
+		RetryConfig:             c.RetryConfig,
+		ReadAfterWriteEnabled:   c.ReadAfterWriteEnabled,
+		ReadAfterWriteAllowlist: c.ReadAfterWriteAllowlist,
 	}}, nil
 }

--- a/internal/consumer/options.go
+++ b/internal/consumer/options.go
@@ -2,24 +2,24 @@ package consumer
 
 import (
 	"fmt"
-	"github.com/project-kessel/inventory-api/internal/consumer/retry"
 
 	"github.com/spf13/pflag"
 )
 
 type Options struct {
-	Enabled            bool           `mapstructure:"enabled"`
-	BootstrapServers   string         `mapstructure:"bootstrap-servers"`
-	ConsumerGroupID    string         `mapstructure:"consumer-group-id"`
-	Topic              string         `mapstructure:"topic"`
-	SessionTimeout     string         `mapstructure:"session-timeout"`
-	HeartbeatInterval  string         `mapstructure:"heartbeat-interval"`
-	MaxPollInterval    string         `mapstructure:"max-poll-interval"`
-	EnableAutoCommit   string         `mapstructure:"enable-auto-commit"`
-	AutoOffsetReset    string         `mapstructure:"auto-offset-reset"`
-	StatisticsInterval string         `mapstructure:"statistics-interval-ms"`
-	Debug              string         `mapstructure:"debug"`
-	RetryOptions       *retry.Options `mapstructure:"retry-options"`
+	Enabled                 bool     `mapstructure:"enabled"`
+	BootstrapServers        string   `mapstructure:"bootstrap-servers"`
+	ConsumerGroupID         string   `mapstructure:"consumer-group-id"`
+	Topic                   string   `mapstructure:"topic"`
+	ReadAfterWriteEnabled   bool     `mapstructure:"read-after-write-enabled"`
+	ReadAfterWriteAllowlist []string `mapstructure:"read-after-write-allowlist"`
+	SessionTimeout          string   `mapstructure:"session-timeout"`
+	HeartbeatInterval       string   `mapstructure:"heartbeat-interval"`
+	MaxPollInterval         string   `mapstructure:"max-poll-interval"`
+	EnableAutoCommit        string   `mapstructure:"enable-auto-commit"`
+	AutoOffsetReset         string   `mapstructure:"auto-offset-reset"`
+	StatisticsInterval      string   `mapstructure:"statistics-interval-ms"`
+	Debug                   string   `mapstructure:"debug"`
 }
 
 func NewOptions() *Options {
@@ -34,7 +34,6 @@ func NewOptions() *Options {
 		AutoOffsetReset:    "earliest",
 		StatisticsInterval: "60000",
 		Debug:              "",
-		RetryOptions:       retry.NewOptions(),
 	}
 }
 
@@ -46,6 +45,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.StringVar(&o.BootstrapServers, prefix+"bootstrap-servers", o.BootstrapServers, "sets the bootstrap server address and port for Kafka")
 	fs.StringVar(&o.ConsumerGroupID, prefix+"consumer-groupd-id", o.ConsumerGroupID, "sets the Kafka consumer group name (default: inventory-consumer)")
 	fs.StringVar(&o.Topic, prefix+"topic", o.Topic, "Kafka topic to monitor for events")
+	fs.BoolVar(&o.ReadAfterWriteEnabled, prefix+"read-after-write-enabled", o.ReadAfterWriteEnabled, "Toggle for enabling or disabling the read after write consistency workflow (default: true)")
+	fs.StringArrayVar(&o.ReadAfterWriteAllowlist, prefix+"read-after-write-allowlist", o.ReadAfterWriteAllowlist, "List of services that require all requests to be read-after-write enabled (default: [])")
 	fs.StringVar(&o.SessionTimeout, prefix+"session-timeout", o.SessionTimeout, "time a consumer can live without sending heartbeat (default: 45000ms)")
 	fs.StringVar(&o.HeartbeatInterval, prefix+"heartbeat-interval", o.HeartbeatInterval, "interval between heartbeats sent to Kafka (default: 3000ms, must be lower then session-timeout)")
 	fs.StringVar(&o.MaxPollInterval, prefix+"max-poll", o.MaxPollInterval, "length of time consumer can go without polling before considered dead (default: 300000ms)")

--- a/internal/consumer/options.go
+++ b/internal/consumer/options.go
@@ -3,37 +3,42 @@ package consumer
 import (
 	"fmt"
 
+	"github.com/project-kessel/inventory-api/internal/consumer/retry"
 	"github.com/spf13/pflag"
 )
 
 type Options struct {
-	Enabled                 bool     `mapstructure:"enabled"`
-	BootstrapServers        string   `mapstructure:"bootstrap-servers"`
-	ConsumerGroupID         string   `mapstructure:"consumer-group-id"`
-	Topic                   string   `mapstructure:"topic"`
-	ReadAfterWriteEnabled   bool     `mapstructure:"read-after-write-enabled"`
-	ReadAfterWriteAllowlist []string `mapstructure:"read-after-write-allowlist"`
-	SessionTimeout          string   `mapstructure:"session-timeout"`
-	HeartbeatInterval       string   `mapstructure:"heartbeat-interval"`
-	MaxPollInterval         string   `mapstructure:"max-poll-interval"`
-	EnableAutoCommit        string   `mapstructure:"enable-auto-commit"`
-	AutoOffsetReset         string   `mapstructure:"auto-offset-reset"`
-	StatisticsInterval      string   `mapstructure:"statistics-interval-ms"`
-	Debug                   string   `mapstructure:"debug"`
+	Enabled                 bool           `mapstructure:"enabled"`
+	BootstrapServers        string         `mapstructure:"bootstrap-servers"`
+	ConsumerGroupID         string         `mapstructure:"consumer-group-id"`
+	Topic                   string         `mapstructure:"topic"`
+	SessionTimeout          string         `mapstructure:"session-timeout"`
+	HeartbeatInterval       string         `mapstructure:"heartbeat-interval"`
+	MaxPollInterval         string         `mapstructure:"max-poll-interval"`
+	EnableAutoCommit        string         `mapstructure:"enable-auto-commit"`
+	AutoOffsetReset         string         `mapstructure:"auto-offset-reset"`
+	StatisticsInterval      string         `mapstructure:"statistics-interval-ms"`
+	Debug                   string         `mapstructure:"debug"`
+	RetryOptions            *retry.Options `mapstructure:"retry-options"`
+	ReadAfterWriteEnabled   bool           `mapstructure:"read-after-write-enabled"`
+	ReadAfterWriteAllowlist []string       `mapstructure:"read-after-write-allowlist"`
 }
 
 func NewOptions() *Options {
 	return &Options{
-		Enabled:            true,
-		ConsumerGroupID:    "inventory-consumer",
-		Topic:              "outbox.event.kessel.tuples",
-		SessionTimeout:     "45000",
-		HeartbeatInterval:  "3000",
-		MaxPollInterval:    "300000",
-		EnableAutoCommit:   "false",
-		AutoOffsetReset:    "earliest",
-		StatisticsInterval: "60000",
-		Debug:              "",
+		Enabled:                 true,
+		ConsumerGroupID:         "inventory-consumer",
+		Topic:                   "outbox.event.kessel.tuples",
+		SessionTimeout:          "45000",
+		HeartbeatInterval:       "3000",
+		MaxPollInterval:         "300000",
+		EnableAutoCommit:        "false",
+		AutoOffsetReset:         "earliest",
+		StatisticsInterval:      "60000",
+		Debug:                   "",
+		RetryOptions:            retry.NewOptions(),
+		ReadAfterWriteEnabled:   true,
+		ReadAfterWriteAllowlist: []string{},
 	}
 }
 

--- a/internal/pubsub/driver.go
+++ b/internal/pubsub/driver.go
@@ -1,0 +1,118 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Driver interface {
+	Close(ctx context.Context) error
+	Connect(ctx context.Context) error
+	Listen(ctx context.Context) error
+	Ping(ctx context.Context) error
+	WaitForNotification(ctx context.Context) (*Notification, error)
+	Notify(ctx context.Context, payload string) error
+}
+
+func NewDriver(dbp *pgxpool.Pool) Driver {
+	return &driver{
+		mu:     sync.Mutex{},
+		dbPool: dbp,
+	}
+}
+
+type driver struct {
+	conn   *pgxpool.Conn
+	dbPool *pgxpool.Pool
+	mu     sync.Mutex
+}
+
+func (d *driver) Close(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.conn == nil {
+		return nil
+	}
+	err := d.conn.Conn().Close(ctx)
+	d.conn.Release()
+	d.conn = nil
+
+	return err
+}
+
+func (d *driver) Connect(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.conn != nil {
+		return errors.New("connection already established")
+	}
+
+	conn, err := d.dbPool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	d.conn = conn
+	return nil
+}
+
+func (d *driver) Listen(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, err := d.conn.Exec(ctx, "listen consumer_notifications")
+	return err
+}
+
+func (d *driver) Ping(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.conn.Ping(ctx)
+}
+
+func (d *driver) WaitForNotification(ctx context.Context) (*Notification, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// If the connection has been lost for some reason, re-establish it
+	if d.conn == nil || d.conn.Conn().IsClosed() {
+		d.conn.Release()
+		d.conn = nil
+
+		if err := d.Connect(ctx); err != nil {
+			return nil, fmt.Errorf("waitForNotification: error re-establishing pgx connection: %w", err)
+		}
+	}
+
+	pgn, err := d.conn.Conn().WaitForNotification(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n := Notification{
+		Channel: pgn.Channel,
+		Payload: []byte(pgn.Payload),
+	}
+
+	return &n, nil
+}
+
+func (d *driver) Notify(ctx context.Context, payload string) error {
+	// If the connection has been lost for some reason, re-establish it
+	if d.conn == nil || d.conn.Conn().IsClosed() {
+		d.conn.Release()
+		d.conn = nil
+
+		if err := d.Connect(ctx); err != nil {
+			return fmt.Errorf("notify: error re-establishing pgx connection: %w", err)
+		}
+	}
+	_, err := d.conn.Exec(ctx, `select pg_notify('consumer_notifications', $1)`, payload)
+	return err
+}

--- a/internal/pubsub/listenmanager.go
+++ b/internal/pubsub/listenmanager.go
@@ -1,0 +1,158 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+type ListenManagerImpl interface {
+	Subscribe(txId string) Subscription
+	Run(ctx context.Context) error
+}
+
+type Subscription interface {
+	NotificationC() <-chan []byte
+	Unsubscribe(ctx context.Context)
+	BlockForNotification(ctx context.Context) error
+}
+
+type Notification struct {
+	Channel string `json:"channel"`
+	Payload []byte `json:"payload"`
+}
+
+type subscription struct {
+	txId          string
+	listenChan    chan []byte
+	listenManager *ListenManager
+	unsubOnce     sync.Once
+}
+
+func (s *subscription) NotificationC() <-chan []byte { return s.listenChan }
+
+func (s *subscription) Unsubscribe(ctx context.Context) {
+	s.unsubOnce.Do(func() {
+		// Unlisten uses background context in case of cancellation.
+		if err := s.listenManager.unsubscribe(context.Background(), s); err != nil {
+			s.listenManager.logger.Error("error unlistening on channel", "err", err, "txId", s.txId)
+		}
+	})
+}
+
+func (s *subscription) BlockForNotification(ctx context.Context) error {
+	s.listenManager.logger.Debugf("Blocking for notification: %v", s.txId)
+	for {
+		select {
+		case notification := <-s.NotificationC():
+			if string(notification) == s.txId {
+				return nil
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("Context cancelled while waiting for notification")
+		}
+	}
+}
+
+type ListenManager struct {
+	mu                        sync.RWMutex
+	logger                    *log.Helper
+	driver                    Driver
+	subscriptions             map[string]*subscription
+	waitForNotificationCancel context.CancelFunc
+}
+
+var _ ListenManagerImpl = &ListenManager{}
+
+func NewListenManager(logger *log.Helper, driver Driver) *ListenManager {
+	return &ListenManager{
+		mu:                        sync.RWMutex{},
+		logger:                    logger,
+		driver:                    driver,
+		subscriptions:             make(map[string]*subscription),
+		waitForNotificationCancel: context.CancelFunc(func() {}),
+	}
+}
+
+type channelChange struct {
+	channel   string
+	close     func()
+	operation string
+}
+
+func (l *ListenManager) Subscribe(txId string) Subscription {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	sub := &subscription{
+		txId:          txId,
+		listenChan:    make(chan []byte, 2),
+		listenManager: l,
+	}
+	l.subscriptions[txId] = sub
+
+	return sub
+}
+
+func (l *ListenManager) waitAndDistribute(ctx context.Context) error {
+	notification, err := func() (*Notification, error) {
+		const listenTimeout = 30 * time.Second
+
+		timeoutCtx, cancel := context.WithTimeout(ctx, listenTimeout)
+		defer cancel()
+
+		notification, err := l.driver.WaitForNotification(timeoutCtx)
+		if err != nil {
+			return nil, fmt.Errorf("error waiting for notification: %w", err)
+		}
+
+		return notification, nil
+	}()
+	if err != nil {
+		// If the error was a cancellation or the deadline being exceeded but
+		// there's no error in the parent context, return no error.
+		if (errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded)) && ctx.Err() == nil {
+			return nil
+		}
+
+		return err
+	}
+
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	for _, sub := range l.subscriptions {
+		select {
+		case sub.listenChan <- []byte(notification.Payload):
+		default:
+			l.logger.Error("dropped notification due to full buffer", "payload", notification.Payload)
+		}
+	}
+
+	return nil
+}
+
+func (l *ListenManager) unsubscribe(ctx context.Context, sub *subscription) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.subscriptions, sub.txId)
+
+	l.logger.Debugf("removed subscription by txId: %s", sub.txId)
+
+	return nil
+}
+
+func (l *ListenManager) Run(ctx context.Context) error {
+	for {
+		err := l.waitAndDistribute(ctx)
+		if err != nil || ctx.Err() != nil {
+			return err
+		}
+	}
+}

--- a/internal/pubsub/notifier.go
+++ b/internal/pubsub/notifier.go
@@ -1,0 +1,17 @@
+package pubsub
+
+import (
+	"context"
+)
+
+type Notifier struct {
+	driver Driver
+}
+
+func NewNotifier(driver Driver) *Notifier {
+	return &Notifier{driver: driver}
+}
+
+func (n *Notifier) Notify(ctx context.Context, payload string) error {
+	return n.driver.Notify(ctx, payload)
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-kratos/kratos/v2/log"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -37,4 +39,24 @@ func New(c CompletedConfig, logger *log.Helper) (*gorm.DB, error) {
 	}
 
 	return db, nil
+}
+func NewPgx(c CompletedConfig, logger *log.Helper) (*pgxpool.Pool, error) {
+	ctx := context.Background()
+	logger.Info("Persistence disabled: ", c.Options.DisablePersistence)
+
+	if c.Options.DisablePersistence || c.Options.Database != "postgres" {
+		logger.Info("Skipping database connection for PGX...")
+		return nil, nil
+	}
+
+	pool, err := pgxpool.New(ctx, c.DSN)
+
+	if err != nil {
+		return nil, fmt.Errorf("error pgx connection to DB: %v", err)
+	}
+	if err = pool.Ping(ctx); err != nil {
+		return nil, fmt.Errorf("error pgx pinging DB: %v", err)
+	}
+
+	return pool, nil
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds 2 new server config options to the consumer, `read-after-write-enabled` & `read-after-write-allowlist`
- - `read-after-write-enabled` if false will disable read after write flow for all requests
- - if `read-after-write-enabled` is true & SP is in `read-after-write-allowlist`, create requests will go through the read after write flow. (other types soon)
- Some updates so the consumer config is available to the usecase struct.

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-38740 & https://issues.redhat.com/browse/RHCLOUD-38741

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

